### PR TITLE
Fixes for tracking burner account requirements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,23 +8,22 @@
 			"name": "absurd-use",
 			"version": "0.0.1",
 			"dependencies": {
-				"@flashbots/ethers-provider-bundle": "^0.6.1",
-				"ether-state": "^0.1.0",
-				"ethers": "^5.7.2",
-				"funtypes": "^5.0.3"
+				"@flashbots/ethers-provider-bundle": "0.6.1",
+				"ethers": "5.7.2",
+				"funtypes": "5.0.3"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-static": "^1.0.0",
-				"@sveltejs/kit": "^1.0.0",
-				"autoprefixer": "^10.4.13",
-				"postcss": "^8.4.20",
-				"prettier-plugin-svelte": "^2.9.0",
-				"svelte": "^3.54.0",
-				"svelte-check": "^2.9.2",
-				"tailwindcss": "^3.2.4",
-				"tslib": "^2.4.1",
-				"typescript": "^4.9.3",
-				"vite": "^4.0.0"
+				"@sveltejs/adapter-static": "1.0.0",
+				"@sveltejs/kit": "1.0.0",
+				"autoprefixer": "10.4.13",
+				"postcss": "8.4.20",
+				"prettier-plugin-svelte": "2.9.0",
+				"svelte": "3.54.0",
+				"svelte-check": "2.9.2",
+				"tailwindcss": "3.2.4",
+				"tslib": "2.4.1",
+				"typescript": "4.9.3",
+				"vite": "4.0.0"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -1134,9 +1133,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.1.tgz",
-			"integrity": "sha512-C41aCaDjA7xoUdsrc/lSdU1059UdLPIRE1vEIRRynzpMujNgp82bTMHkDosb6vykH6LrLf3tT2w2/5NYQhKYGQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0.tgz",
+			"integrity": "sha512-6VgD5C3i2XOT7GRBi5LaPPLiFAmpiDkhKJNVt8fLg1RmaL6f7rT4Kiwi2XGpYRj3V1F4t1QRdsfmAkkDUKY3OA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -1158,7 +1157,7 @@
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": "^16.14 || >=18"
+				"node": ">=16.14"
 			},
 			"peerDependencies": {
 				"svelte": "^3.54.0",
@@ -1658,14 +1657,6 @@
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
 			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
 			"dev": true
-		},
-		"node_modules/ether-state": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ether-state/-/ether-state-0.1.0.tgz",
-			"integrity": "sha512-lqNWFEu9MMgK98uhrn/eB7QvYCSHhs7N6EstINLmQ7qEbvUGbtyng+M257oukStp/E4PevGRIrbrGBt4/QZaDw==",
-			"dependencies": {
-				"ethers": "^5.7.2"
-			}
 		},
 		"node_modules/ethers": {
 			"version": "5.7.2",
@@ -2621,18 +2612,18 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.55.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
-			"integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.54.0.tgz",
+			"integrity": "sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
-			"integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.9.2.tgz",
+			"integrity": "sha512-DRi8HhnCiqiGR2YF9ervPGvtoYrheE09cXieCTEqeTPOTJzfoa54Py8rovIBv4bH4n5HgZYIyTQ3DDLHQLl2uQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.9",
@@ -2829,9 +2820,9 @@
 			"dev": true
 		},
 		"node_modules/typescript": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -2886,13 +2877,13 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.0.3.tgz",
-			"integrity": "sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
+			"integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.16.3",
-				"postcss": "^8.4.20",
+				"postcss": "^8.4.19",
 				"resolve": "^1.22.1",
 				"rollup": "^3.7.0"
 			},
@@ -3587,9 +3578,9 @@
 			"requires": {}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.1.tgz",
-			"integrity": "sha512-C41aCaDjA7xoUdsrc/lSdU1059UdLPIRE1vEIRRynzpMujNgp82bTMHkDosb6vykH6LrLf3tT2w2/5NYQhKYGQ==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0.tgz",
+			"integrity": "sha512-6VgD5C3i2XOT7GRBi5LaPPLiFAmpiDkhKJNVt8fLg1RmaL6f7rT4Kiwi2XGpYRj3V1F4t1QRdsfmAkkDUKY3OA==",
 			"dev": true,
 			"requires": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -3967,14 +3958,6 @@
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
 			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
 			"dev": true
-		},
-		"ether-state": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ether-state/-/ether-state-0.1.0.tgz",
-			"integrity": "sha512-lqNWFEu9MMgK98uhrn/eB7QvYCSHhs7N6EstINLmQ7qEbvUGbtyng+M257oukStp/E4PevGRIrbrGBt4/QZaDw==",
-			"requires": {
-				"ethers": "^5.7.2"
-			}
 		},
 		"ethers": {
 			"version": "5.7.2",
@@ -4640,15 +4623,15 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "3.55.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
-			"integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.54.0.tgz",
+			"integrity": "sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==",
 			"dev": true
 		},
 		"svelte-check": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
-			"integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.9.2.tgz",
+			"integrity": "sha512-DRi8HhnCiqiGR2YF9ervPGvtoYrheE09cXieCTEqeTPOTJzfoa54Py8rovIBv4bH4n5HgZYIyTQ3DDLHQLl2uQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.9",
@@ -4767,9 +4750,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true
 		},
 		"undici": {
@@ -4798,14 +4781,14 @@
 			"dev": true
 		},
 		"vite": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.0.3.tgz",
-			"integrity": "sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
+			"integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
 			"dev": true,
 			"requires": {
 				"esbuild": "^0.16.3",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.20",
+				"postcss": "^8.4.19",
 				"resolve": "^1.22.1",
 				"rollup": "^3.7.0"
 			}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 	"type": "module",
 	"dependencies": {
 		"@flashbots/ethers-provider-bundle": "0.6.1",
-		"ether-state": "0.1.0",
 		"ethers": "5.7.2",
 		"funtypes": "5.0.3"
 	}

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -3,7 +3,6 @@ import { env } from '$env/dynamic/public'
 import { derived, get, readable, writable } from 'svelte/store'
 import { providers, utils, Wallet } from 'ethers'
 import { EthereumAddress, GetSimulationStackReply, serialize } from '$lib/types'
-import type { Sync } from 'ether-state'
 import { getMaxBaseFeeInFutureBlock } from './bundleUtils'
 
 export const ssr = false
@@ -12,8 +11,6 @@ export const ssr = false
 export const provider = writable<providers.Provider>(
 	new providers.JsonRpcProvider(env.PUBLIC_RPC_URL),
 )
-export const blockSync = writable<Sync>()
-
 export const latestBlock = writable<{
 	blockNumber: bigint
 	baseFee: bigint
@@ -88,8 +85,15 @@ export const totalValue = derived(
 	},
 )
 export const fundingAmountMin = derived(
-	[totalGas, totalValue, priorityFee, latestBlock],
-	([$totalGas, $totalValue, $priorityFee, $latestBlock]) => {
+	[bundleContainsFundingTx, totalGas, totalValue, priorityFee, latestBlock],
+	([
+		$bundleContainsFundingTx,
+		$totalGas,
+		$totalValue,
+		$priorityFee,
+		$latestBlock,
+	]) => {
+		if (!$bundleContainsFundingTx) return 0n
 		const maxBaseFee = getMaxBaseFeeInFutureBlock($latestBlock.baseFee, 2)
 		return $totalGas * ($priorityFee + maxBaseFee) + $totalValue
 	},

--- a/src/routes/app/+layout.ts
+++ b/src/routes/app/+layout.ts
@@ -1,59 +1,33 @@
 import { browser } from '$app/environment'
 import {
-	blockSync,
 	fundingAccountBalance,
 	latestBlock,
 	provider,
 	wallet,
 } from '$lib/state'
-import { Sync, Trigger } from 'ether-state'
-import { BigNumber, constants, utils } from 'ethers'
 import { get } from 'svelte/store'
 
 // Don't run on server
 export const ssr = false
 
-const IMulticall = new utils.Interface([
-	'function getEthBalance(address addr) external view returns (uint256 balance)',
-])
-
-if (!get(blockSync) && browser) {
-	blockSync.set(
-		new Sync(
-			[
-				{
-					trigger: Trigger.BLOCK,
-					input: (blockNumber: BigNumber) => {
-						updateLatestBlock(blockNumber.toBigInt())
-
-						return [get(wallet)?.address ?? constants.AddressZero]
-					},
-					call: {
-						// Multicall2: Balance of funding account
-						target: () => '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
-						interface: IMulticall,
-						selector: 'getEthBalance',
-					},
-					output: ([balance]: [BigNumber]) => {
-						fundingAccountBalance.set(
-							get(wallet)?.address !== constants.AddressZero
-								? balance.toBigInt()
-								: 0n,
-						)
-					},
-				},
-			],
-			get(provider),
-		),
-	)
+async function blockCallback(blockNumber: number) {
+	updateLatestBlock(blockNumber)
+	if (get(wallet)) {
+		const bal = await get(provider).getBalance(get(wallet).address)
+		fundingAccountBalance.set(bal.toBigInt())
+	}
 }
 
-async function updateLatestBlock(blockNumber: bigint) {
-	const block = await get(provider).getBlock(Number(blockNumber))
+async function updateLatestBlock(blockNumber: number) {
+	const block = await get(provider).getBlock(blockNumber)
 	const baseFee = block.baseFeePerGas?.toBigInt() ?? 0n
 	latestBlock.update((lastBlock) => {
-		if (!lastBlock || blockNumber > lastBlock.blockNumber) {
-			return { blockNumber, baseFee }
+		if (!lastBlock || BigInt(blockNumber) > lastBlock.blockNumber) {
+			return { blockNumber: BigInt(blockNumber), baseFee }
 		} else return lastBlock
 	})
+}
+
+if (browser && get(provider) && get(provider).listenerCount('block') === 0) {
+	get(provider).on('block', blockCallback)
 }


### PR DESCRIPTION
Simplified tracking block baseFee and burner wallet's balance - Now no longer makes a call to check balance if there is no burner
Removed ether-state dependency as its not needed anymore
``$fundingAccountMin`` checks to see if there is a burner account needed and now returns 0 if not

Resolved #3 and #10 