### PR TITLE
 Add link to absurd uses GitHub page to readme.md #17 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Absurd-Use
 
+Turn your [Interceptor](https://github.com/DarkFlorist/TheInterceptor) simulations into MEV bundles.
+
+URL: [https://absurd-use.dark.florist/](https://absurd-use.dark.florist/)
+IPFS: Soon
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Resolves Add link to absurd uses GitHub page to readme.md #17 