### PR TITLE
Fix: Resolve @types/node 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@preact/signals": "1.1.1",
+				"@types/node": "npm:@types/web",
 				"ethers": "6.6.2",
 				"funtypes": "5.0.3",
 				"preact": "10.8.1"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"build": "tsc",
 		"watch": "tsc --watch",
+		"trace": "tsc --traceResolution",
 		"serve": "npx http-server ./app",
 		"vendor": "npm ci --ignore-scripts && cd build && npm ci --ignore-scripts && npm run vendor",
 		"styles": "cd twcss && npm run styles"
@@ -16,6 +17,7 @@
 		"@preact/signals": "1.1.1",
 		"ethers": "6.6.2",
 		"funtypes": "5.0.3",
+		"@types/node": "npm:@types/web",
 		"preact": "10.8.1"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"moduleResolution": "node",
 		"rootDir": "app/ts",
 		"outDir": "app/js",
+		"skipLibCheck": true,
 		"sourceMap": true,
 		"inlineSources": true,
 		"declaration": true,


### PR DESCRIPTION
Basically: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#supporting-lib-from-node_modules

If that does not work, `skipLibCheck` does the job. 

Additionally if your wanting to do more profiling

```jsonc
"baseline": "npx tsc --extendedDiagnostics",
"explain": "npx tsc --explainFiles > explanation.txt",
"trace": "npx tsc --traceResolution > resolution.txt",
"profile": "node --trace-ic ./node_modules/typescript/lib/tsc.js --generateCpuProfile profile.cpuprofile -p tsconfig.json",
"tracer": "mkdir -p tmp_folder/ && npx tsc -p ./tsconfig.json --generateTrace tmp_folder",
```