### PR TITLE
Wrong net ETH needed for funding

### DIFF
--- a/app/ts/components/Import.tsx
+++ b/app/ts/components/Import.tsx
@@ -60,12 +60,11 @@ export async function importFromInterceptor(
 	const fundingRecipients = new Set(converted.value.reduce((result: bigint[], tx) => (tx.to && tx.from === 'FUNDING' ? [...result, tx.to] : result), []))
 	const spenderDeficits = tryParse.value.reduce((amounts: { [account: string]: bigint }, tx) => {
 		if (!fundingRecipients.has(tx.from)) return amounts
-		const txDiff = tx.value - tx.balanceChanges.filter(x => x.address === tx.from).reduce((sum, bal) => sum + bal.before - bal.after, 0n) + tx.maxPriorityFeePerGas * tx.gasSpent
+		const txDiff = tx.balanceChanges.filter(x => x.address === tx.from).reduce((sum, bal) => sum + bal.before - bal.after, 0n) + tx.maxPriorityFeePerGas * tx.gasSpent
 		const amount = amounts[tx.from.toString()] ? amounts[tx.from.toString()] + txDiff : txDiff
 		amounts[tx.from.toString()] = amount
 		return amounts
 	}, {})
-
 	const inputValue = Object.values(spenderDeficits).reduce((sum, amount) => amount + sum, 0n)
 
 	// Copy value and set, input of funding to inputValue

--- a/app/ts/components/Transactions.tsx
+++ b/app/ts/components/Transactions.tsx
@@ -76,7 +76,7 @@ export const Transactions = ({
 						const implReq = await fetch(`https://api${appSettings.peek().relayEndpoint === MEV_RELAY_GOERLI ? '-goerli' : ''}.etherscan.io/api?module=contract&action=getabi&address=${addressString(contract.value.result[0].Implementation)}&apiKey=PSW8C433Q667DVEX5BCRMGNAH9FSGFZ7Q8`)
 						const implResult = EtherscanGetABIResult.safeParse(await implReq.json())
 						abis.push(implResult.success && implResult.value.status === '1' ? implResult.value.result : undefined)
-					} else abis.push(contract.value.result[0].ABI ?? undefined)
+					} else abis.push(contract.value.result[0].ABI && contract.value.result[0].ABI !== 'Contract source code not verified' ? contract.value.result[0].ABI : undefined)
 				}
 			}
 


### PR DESCRIPTION
Now funding account asks for the correct amount of needed ETH (before it was only looking for gas).
And it still only asks for the net amount needed,

For example this account had 0.35 WETH, and we made 2 two transactions of unwrap 0.35 and then wrap 1. It correctly identifies that we only need 0.65 extra + gas.
![image](https://github.com/DarkFlorist/bouquet/assets/52896585/a2d9b3ed-3ece-4301-b780-d4d2a2f7045e)


Also found missed edge case for decoding transactions when they were both not verified or proxies.