### PR TITLE
Fix docker build with curl update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN npm run build
 FROM ipfs/kubo:v0.25.0@sha256:0c17b91cab8ada485f253e204236b712d0965f3d463cb5b60639ddd2291e7c52 as ipfs-kubo
 
 # Create the base image
-FROM debian:12.2-slim@sha256:93ff361288a7c365614a5791efa3633ce4224542afb6b53a1790330a8e52fc7d
+FROM debian:12.6-slim@sha256:39868a6f452462b70cf720a8daff250c63e7342970e749059c105bf7c1e8eeaf
 
 # Add curl to the base image (7.88.1-10+deb12u6)
 # Add jq to the base image (1.6-2.1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ FROM ipfs/kubo:v0.25.0@sha256:0c17b91cab8ada485f253e204236b712d0965f3d463cb5b606
 # Create the base image
 FROM debian:12.2-slim@sha256:93ff361288a7c365614a5791efa3633ce4224542afb6b53a1790330a8e52fc7d
 
-# Add curl to the base image (7.88.1-10+deb12u5)
+# Add curl to the base image (7.88.1-10+deb12u6)
 # Add jq to the base image (1.6-2.1)
-RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u5 jq=1.6-2.1
+RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u6 jq=1.6-2.1
 
 # Install kubo and initialize ipfs
 COPY --from=ipfs-kubo /usr/local/bin/ipfs /usr/local/bin/ipfs


### PR DESCRIPTION
Seems `curl 7.88.1-10+deb12u5` no longer exist or has been moved from apt repository that causes CI to fail to build

> 14.41 Some packages could not be installed. This may mean that you have
14.41 requested an impossible situation or if you are using the unstable
14.41 distribution that some required packages have not yet been created
14.41 or been moved out of Incoming.
14.41 The following information may help to resolve the situation:
14.41
14.41 The following packages have unmet dependencies:
14.65  curl : Depends: libcurl4 (= 7.88.1-10+deb12u5) but 7.88.1-10+deb12u6 is to be installed

- Updated ipfs base image from [debian:12.2-slim](https://hub.docker.com/layers/library/debian/12.2-slim/images/sha256-93ff361288a7c365614a5791efa3633ce4224542afb6b53a1790330a8e52fc7d) to [debian:12.6-slim](https://hub.docker.com/layers/library/debian/12.6-slim/images/sha256-39868a6f452462b70cf720a8daff250c63e7342970e749059c105bf7c1e8eeaf)
- Updated curl to `7.88.1-10+deb12u6`

