### PR TITLE
Makes docker image use snapshot instead of evergreen repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ FROM debian:12.6-slim@sha256:39868a6f452462b70cf720a8daff250c63e7342970e749059c1
 
 # Add curl to the base image (7.88.1-10+deb12u6)
 # Add jq to the base image (1.6-2.1)
-RUN apt-get update && apt-get install -y curl=7.88.1-10+deb12u6 jq=1.6-2.1
+RUN sed -i 's/URIs/# URIs/g' /etc/apt/sources.list.d/debian.sources && \
+	sed -i 's/# http/URIs: http/g' /etc/apt/sources.list.d/debian.sources && \
+	apt-get update -o Acquire::Check-Valid-Until=false && apt-get install -y curl=7.88.1-10+deb12u6 jq=1.6-2.1
 
 # Install kubo and initialize ipfs
 COPY --from=ipfs-kubo /usr/local/bin/ipfs /usr/local/bin/ipfs


### PR DESCRIPTION
The `sed` just comments out the evergreen package repository and uncomments the snapshot repository associated with the base image.

The snapshot repositories automatically "expire", so we have to tell apt to ignore expiration dates with `-o Acquire::Check-Valid-Until=false`.

Rolled back curl by one version so we are using the version that was available at the time the base debian image was built.