### PR TITLE
Adds missing `id` property on eth_callBundle JSON-RPC request.

### DIFF
--- a/app/ts/library/flashbots.ts
+++ b/app/ts/library/flashbots.ts
@@ -128,7 +128,7 @@ export async function simulateBundle(
 		}
 		case 'relay': {
 			if (network.simulationRelayEndpoint === undefined) throw new Error('simulationRelayEndpoint is not defined')
-			const payload = JSON.stringify({ jsonrpc: '2.0', method: 'eth_callBundle', params: [{ txs: txs.map((x) => x.rawTransaction), blockNumber: `0x${blockInfo.blockNumber.toString(16)}`, stateBlockNumber: 'latest' }] })
+			const payload = JSON.stringify({ jsonrpc: '2.0', id: 0, method: 'eth_callBundle', params: [{ txs: txs.map((x) => x.rawTransaction), blockNumber: `0x${blockInfo.blockNumber.toString(16)}`, stateBlockNumber: 'latest' }] })
 			const flashbotsSig = `${await provider.authSigner.getAddress()}:${await provider.authSigner.signMessage(id(payload))}`
 			const request = await fetch(network.simulationRelayEndpoint,
 				{ method: 'POST', body: payload, headers: { 'Content-Type': 'application/json', 'X-Flashbots-Signature': flashbotsSig } }


### PR DESCRIPTION
`https://relay.flashbots.net` started requiring this out of the blue.